### PR TITLE
documentation: prefer org-directory over string path in example

### DIFF
--- a/README.org
+++ b/README.org
@@ -17,6 +17,6 @@ Because of these characteristics, it's simple and lightweight.  To use, just, e.
 #+begin_src elisp
   (add-hook 'org-mode-hook
             (lambda ()
-              (when (file-in-directory-p (buffer-file-name) "~/org")
+              (when (file-in-directory-p (buffer-file-name) org-directory)
                 (salv-mode))))
 #+end_src


### PR DESCRIPTION
This should be a little cleaner and make it easier for other users to copy over the code.